### PR TITLE
Fix missing username placeholder

### DIFF
--- a/hasil2.html
+++ b/hasil2.html
@@ -24,7 +24,7 @@
         <!-- Result Card -->
         <div class="result-card text-center">
             <small>Terima kasih telah mengikuti rangkaian pembelajaran</small>
-            <h4>Restu Bias Primandhika</h4>
+            <h4><span id="userName"></span></h4>
             <h5>Training ID: <span class="text-primary">ID#000029</span></h5>
             <div class="alert alert-primary" role="alert">Penilaian dalam proses...</div>
             <p class="text-danger"><strong>Harap mengingat ID Anda dan screenshot sebelum meninggalkan halaman.</strong></p>


### PR DESCRIPTION
## Summary
- add user name span to results card in `hasil2.html`

## Testing
- `grep -n "userName" -n hasil2.html`

------
https://chatgpt.com/codex/tasks/task_e_683fa45513a48333a9c0b1c682684b24